### PR TITLE
Add media to watchlists component

### DIFF
--- a/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
+++ b/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
@@ -40,11 +40,11 @@ export default function AddMediaToWatchListSelect({
   const handleAddToWatchList = async () => {
     if (!selectedWatchList || !mediaItemDTO.mediaType) {
       try {
-        [movieResult, tvResult] = await Promise.all([
+        const [movieResult, tvResult]: [Response, Response] = await Promise.all([
           fetch(`https://api.themoviedb.org/3/movie/${mediaItemDTO.tmdbId}?api_key=${}`),
           fetch(`https://api.themoviedb.org/3/tv/${mediaItemDTO.tmdbId}?api_key=${}`),
         ])
-        const [movieData, tvData] = await Promise.all([movieResult.json(), tvResult.json()])
+        const [movieData, tvData]: [any, any] = await Promise.all([movieResult.json(), tvResult.json()])
 
         if (movieData.name === mediaTitle) {
           mediaItemDTO.mediaType = 'movie'
@@ -59,7 +59,7 @@ export default function AddMediaToWatchListSelect({
         return;
       }
     }
-    
+
       try {
         const response = await fetch(
           `http://localhost:8080/api/add-to-watchlist/${selectedWatchList}`,

--- a/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
+++ b/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
@@ -1,5 +1,76 @@
-// import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { fetchGetWatchLists } from "./ViewWatchLists";
 
-// export default function AddMediaToWatchListSelect() {
-//     const [watchLists, setWatchLists]
-// }
+interface MediaItemDTO {
+  tmdbId: number;
+  mediaType: string;
+}
+
+interface WatchList {
+    id: number;
+    name: string;
+    description: string;
+}
+
+interface AddMediaToWatchListProps {
+    mediaItemDTO: MediaItemDTO;
+}
+
+export default function AddMediaToWatchListSelect({ mediaItemDTO }: AddMediaToWatchListProps) {
+  const [watchLists, setWatchLists] = useState<WatchList[]>([]);
+  const [selectedWatchList, setSelectedWatchList] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function fetchWatchLists() {
+      try {
+        const response = await fetchGetWatchLists();
+        setWatchLists(response);
+      } catch (error) {
+        console.error("Error retrieving Watch Lists: ", error);
+      }
+    }
+    fetchWatchLists();
+  }, []);
+
+  const handleAddToWatchList = async () => {
+    if (!selectedWatchList || !mediaItemDTO) {
+      return console.error("Watch List or Media Item details missing.");
+    }
+
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/add-to-watchlist/${selectedWatchList}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(mediaItemDTO),
+        }
+      );
+      const result = await response.json();
+      return result;
+    } catch (error) {
+      console.error("Error adding media item to watchlist: ", error);
+    }
+  };
+
+  return (
+    <>
+        <div>
+            <form>
+                <select onChange={(event) => setSelectedWatchList(Number(event.target.value))}>
+                    <option value="" disabled>Select a Watch List</option>
+                    {watchLists.map((watchList) => (
+                        <option key={watchList.id} value={watchList.id}>
+                            {watchList.name}
+                        </option>
+                    ))}
+                </select>
+
+                <button type="button" onClick={handleAddToWatchList}></button>
+            </form>
+        </div>
+    </>
+  )
+}

--- a/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
+++ b/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
@@ -7,18 +7,22 @@ interface MediaItemDTO {
 }
 
 interface WatchList {
-    id: number;
-    name: string;
-    description: string;
+  id: number;
+  name: string;
+  description: string;
 }
 
 interface AddMediaToWatchListProps {
-    mediaItemDTO: MediaItemDTO;
+  mediaItemDTO: MediaItemDTO;
 }
 
-export default function AddMediaToWatchListSelect({ mediaItemDTO }: AddMediaToWatchListProps) {
+export default function AddMediaToWatchListSelect({
+  mediaItemDTO,
+}: AddMediaToWatchListProps) {
   const [watchLists, setWatchLists] = useState<WatchList[]>([]);
-  const [selectedWatchList, setSelectedWatchList] = useState<number | null>(null);
+  const [selectedWatchList, setSelectedWatchList] = useState<number | null>(
+    null
+  );
 
   useEffect(() => {
     async function fetchWatchLists() {
@@ -57,20 +61,26 @@ export default function AddMediaToWatchListSelect({ mediaItemDTO }: AddMediaToWa
 
   return (
     <>
-        <div>
-            <form>
-                <select onChange={(event) => setSelectedWatchList(Number(event.target.value))}>
-                    <option value="" disabled>Select a Watch List</option>
-                    {watchLists.map((watchList) => (
-                        <option key={watchList.id} value={watchList.id}>
-                            {watchList.name}
-                        </option>
-                    ))}
-                </select>
+      <div>
+        <form>
+          <select
+            onChange={(event) =>
+              setSelectedWatchList(Number(event.target.value))
+            }
+          >
+            <option value="" disabled>
+              Select a Watch List
+            </option>
+            {watchLists.map((watchList) => (
+              <option key={watchList.id} value={watchList.id}>
+                {watchList.name}
+              </option>
+            ))}
+          </select>
 
-                <button type="button" onClick={handleAddToWatchList}></button>
-            </form>
-        </div>
+          <button type="button" onClick={handleAddToWatchList}></button>
+        </form>
+      </div>
     </>
-  )
+  );
 }

--- a/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
+++ b/telli-react/src/components/AddMediaItemToWatchListSelect.tsx
@@ -1,0 +1,5 @@
+// import React, { useState } from "react";
+
+// export default function AddMediaToWatchListSelect() {
+//     const [watchLists, setWatchLists]
+// }

--- a/telli-react/src/components/DeleteWatchListButton.tsx
+++ b/telli-react/src/components/DeleteWatchListButton.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface DeleteWatchListButtonProps {
+    watchListId: number;
+    onDelete: () => void;
+}
+
+export default function DeleteWatchListButton({ watchListId, onDelete }: DeleteWatchListButtonProps) {
+
+    async function handleDelete() {
+        try {
+            const response = await fetch(`http://localhost:8080/api/delete-watchlist/${watchListId}`, {
+                method: "DELETE",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+            if (response.ok) {
+                onDelete();
+            } else {
+                console.error("Error deleting existing WatchList.")
+            }
+        } catch (error) {
+            console.error("Error deleting existing WatchList: ", error);
+        }
+    }
+
+    return (
+        <>
+            <button onClick={handleDelete}>Delete</button>
+        </>
+    )
+}

--- a/telli-react/src/components/DeleteWatchListButton.tsx
+++ b/telli-react/src/components/DeleteWatchListButton.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 interface DeleteWatchListButtonProps {
     watchListId: number;
     onDelete: () => void;

--- a/telli-react/src/components/DeleteWatchListButton.tsx
+++ b/telli-react/src/components/DeleteWatchListButton.tsx
@@ -1,32 +1,38 @@
 interface DeleteWatchListButtonProps {
-    watchListId: number;
-    onDelete: () => void;
+  watchListId: number;
+  onDelete: () => void;
 }
 
-export default function DeleteWatchListButton({ watchListId, onDelete }: DeleteWatchListButtonProps) {
-
-    async function handleDelete() {
-        try {
-            const response = await fetch(`http://localhost:8080/api/delete-watchlist/${watchListId}`, {
-                method: "DELETE",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-            });
-            if (response.ok) {
-                // POssibly add alert box here before proceeding with deletion?
-                onDelete();
-            } else {
-                console.error("Error deleting existing WatchList.")
-            }
-        } catch (error) {
-            console.error("Error deleting existing WatchList: ", error);
+export default function DeleteWatchListButton({
+  watchListId,
+  onDelete,
+}: DeleteWatchListButtonProps) {
+  async function handleDelete() {
+    if (confirm("Your Watch List will be deleted permanently!")) {
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/delete-watchlist/${watchListId}`,
+          {
+            method: "DELETE",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        );
+        if (response.ok) {
+          onDelete();
+        } else {
+          console.error("Error deleting existing WatchList.");
         }
+      } catch (error) {
+        console.error("Error deleting existing WatchList: ", error);
+      }
     }
+  }
 
-    return (
-        <>
-            <button onClick={handleDelete}>Delete</button>
-        </>
-    )
+  return (
+    <>
+      <button onClick={handleDelete}>Delete</button>
+    </>
+  );
 }

--- a/telli-react/src/components/DeleteWatchListButton.tsx
+++ b/telli-react/src/components/DeleteWatchListButton.tsx
@@ -14,6 +14,7 @@ export default function DeleteWatchListButton({ watchListId, onDelete }: DeleteW
                 },
             });
             if (response.ok) {
+                // POssibly add alert box here before proceeding with deletion?
                 onDelete();
             } else {
                 console.error("Error deleting existing WatchList.")

--- a/telli-react/src/components/EditWatchListButton.tsx
+++ b/telli-react/src/components/EditWatchListButton.tsx
@@ -1,0 +1,14 @@
+interface EditButtonProps {
+    onClick: () => void;
+}
+
+export default function EditWatchListButton({ onClick }: EditButtonProps) {
+
+    return (
+        <>
+            <button onClick={onClick}>
+                Edit
+            </button>
+        </>
+    )
+}

--- a/telli-react/src/components/EditWatchListForm.tsx
+++ b/telli-react/src/components/EditWatchListForm.tsx
@@ -1,8 +1,14 @@
 import React, { useState, useEffect } from "react";
+import { WatchList } from "./ViewWatchLists"
 
 interface EditWatchListDTO {
   newName: string;
   newDescription: string;
+}
+
+interface EditWatchListFormProps {
+    watchList: WatchList;
+    onUpdate: (updatedWatchList: WatchList) => void;
 }
 
 async function fetchEditWatchList(
@@ -26,7 +32,7 @@ async function fetchEditWatchList(
   }
 }
 
-export default function EditWatchListForm({ watchList, onUpdate }) {
+export default function EditWatchListForm({ watchList, onUpdate }: EditWatchListFormProps) {
   async function handleEditWatchList(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 

--- a/telli-react/src/components/EditWatchListForm.tsx
+++ b/telli-react/src/components/EditWatchListForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { WatchList } from "./ViewWatchLists"
 
 interface EditWatchListDTO {

--- a/telli-react/src/components/EditWatchListForm.tsx
+++ b/telli-react/src/components/EditWatchListForm.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+
+interface EditWatchListDTO {
+  newName: string;
+  newDescription: string;
+}
+
+async function fetchEditWatchList(
+  watchListId: number,
+  editWatchListDTO: EditWatchListDTO
+) {
+  try {
+    const response = await fetch(
+      `http://localhost:8080/api/edit-watchlist/${watchListId}`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(editWatchListDTO),
+      }
+    );
+    return response;
+  } catch (error) {
+    console.error("Error updating existing WatchList: ", error);
+  }
+}
+
+export default function EditWatchListForm({ watchList, onUpdate }) {
+  async function handleEditWatchList(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const newName: string = (
+      document.getElementById("newName") as HTMLInputElement
+    ).value;
+    const newDescription: string = (
+      document.getElementById("newDescription") as HTMLInputElement
+    ).value;
+
+    const editWatchListDTO = {
+      newName: newName,
+      newDescription: newDescription,
+    };
+
+    await fetchEditWatchList(watchList.id, editWatchListDTO);
+
+    onUpdate({
+      ...watchList,
+      name: newName,
+      description: newDescription,
+    });
+  }
+
+  return (
+    <>
+      <form onSubmit={handleEditWatchList}>
+        <input
+          type="text"
+          id="newName"
+          name="newName"
+          defaultValue={watchList.name}
+        ></input>
+        <input
+          type="text"
+          id="newDescription"
+          name="newDescription"
+          defaultValue={watchList.description}
+        ></input>
+        <button type="submit">Update</button>
+      </form>
+    </>
+  );
+}

--- a/telli-react/src/components/EditWatchListForm.tsx
+++ b/telli-react/src/components/EditWatchListForm.tsx
@@ -9,6 +9,7 @@ interface EditWatchListDTO {
 interface EditWatchListFormProps {
     watchList: WatchList;
     onUpdate: (updatedWatchList: WatchList) => void;
+    onCancel: () => void;
 }
 
 async function fetchEditWatchList(
@@ -32,7 +33,7 @@ async function fetchEditWatchList(
   }
 }
 
-export default function EditWatchListForm({ watchList, onUpdate }: EditWatchListFormProps) {
+export default function EditWatchListForm({ watchList, onUpdate, onCancel }: EditWatchListFormProps) {
   async function handleEditWatchList(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -73,6 +74,7 @@ export default function EditWatchListForm({ watchList, onUpdate }: EditWatchList
           defaultValue={watchList.description}
         ></input>
         <button type="submit">Update</button>
+        <button type="button" onClick={onCancel}>Cancel</button>
       </form>
     </>
   );

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -50,22 +50,24 @@ export default function DisplayAllWatchLists() {
         <ul>
           {watchLists.map((watchList) => (
             <li key={watchList.id}>
-              <h3>{watchList.name}</h3>
-              <p>{watchList.description}</p>
-              <button onClick={() => handleEditClick(watchList)}>Edit</button>
-              
-              
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      {editingWatchList && (
+              {editingWatchList && editingWatchList.id === watchList.id ? (
                 <EditWatchListForm
                   watchList={editingWatchList}
                   onUpdate={handleUpdatedWatchList}
                 />
-      )}
+              ) : (
+                <>
+                  <h3>{watchList.name}</h3>
+                  <p>{watchList.description}</p>
+                  <button onClick={() => handleEditClick(watchList)}>
+                    Edit
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
     </>
   );
 }

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import EditWatchListForm from "./EditWatchListForm";
 
-interface WatchList {
+export interface WatchList {
   id: number;
   name: string;
   description: string;

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import EditWatchListForm from "./EditWatchListForm";
+import DeleteWatchListButton from "./DeleteWatchListButton";
 
 export interface WatchList {
   id: number;
@@ -39,10 +40,6 @@ export default function DisplayAllWatchLists() {
     setEditingWatchList(null);
   };
 
-  const handleCancelEditClick = () => {
-    setEditingWatchList(null);
-  };
-
   return (
     <>
       <div>
@@ -62,6 +59,7 @@ export default function DisplayAllWatchLists() {
                   <button onClick={() => handleEditClick(watchList)}>
                     Edit
                   </button>
+                  <DeleteWatchListButton onDelete={fetchGetWatchLists} watchListId={watchList.id} />
                 </>
               )}
             </li>

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -9,23 +9,30 @@ export interface WatchList {
   description: string;
 }
 
+export async function fetchGetWatchLists() {
+  try {
+    const response = await fetch("http://localhost:8080/api/get-watchlists");
+    const result = await response.json();
+    return result;
+    
+  } catch (error) {
+    console.error("Error retrieving Watch Lists: ", error);
+  }
+}
+
 export default function DisplayAllWatchLists() {
   const [watchLists, setWatchLists] = useState<WatchList[]>([]);
   const [editingWatchList, setEditingWatchList] = useState<WatchList | null>(
     null
   );
 
-  async function fetchGetWatchLists() {
-    try {
-      const response = await fetch("http://localhost:8080/api/get-watchlists");
-      const result = await response.json();
-      setWatchLists(result);
-    } catch (error) {
-      console.error("Error retrieving Watch Lists: ", error);
-    }
-  }
   useEffect(() => {
-    if (watchLists.length === 0) fetchGetWatchLists();
+    async function fetchData () {
+      const result = await fetchGetWatchLists();
+      setWatchLists(result);
+    }
+
+    if (watchLists.length === 0) fetchData();
   }, [watchLists]);
 
   const handleEditClick = (watchList: WatchList) => {

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -41,6 +41,10 @@ export default function DisplayAllWatchLists() {
     setEditingWatchList(null);
   };
 
+  const handleCancelEdit = () => {
+    setEditingWatchList(null);
+  }
+
   return (
     <>
       <div>
@@ -52,6 +56,7 @@ export default function DisplayAllWatchLists() {
                 <EditWatchListForm
                   watchList={editingWatchList}
                   onUpdate={handleUpdatedWatchList}
+                  onCancel={handleCancelEdit}
                 />
               ) : (
                 <>

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -1,42 +1,71 @@
 import { useState, useEffect } from "react";
+import EditWatchListForm from "./EditWatchListForm";
 
 interface WatchList {
-    id: number,
-    name: string,
-    description: string,
+  id: number;
+  name: string;
+  description: string;
 }
 
 export default function DisplayAllWatchLists() {
-    const [watchLists, setWatchLists] = useState<WatchList[]>([])
+  const [watchLists, setWatchLists] = useState<WatchList[]>([]);
+  const [editingWatchList, setEditingWatchList] = useState<WatchList | null>(
+    null
+  );
 
-    async function fetchGetWatchLists() {
-        try {
-            const response = await fetch('http://localhost:8080/api/get-watchlists');
-            const result = await response.json();
-            setWatchLists(result);
-        } catch (error) {
-            console.error("Error retrieving Watch Lists: ", error);
-        }
+  async function fetchGetWatchLists() {
+    try {
+      const response = await fetch("http://localhost:8080/api/get-watchlists");
+      const result = await response.json();
+      setWatchLists(result);
+    } catch (error) {
+      console.error("Error retrieving Watch Lists: ", error);
     }
+  }
+  useEffect(() => {
+    if (watchLists.length === 0) fetchGetWatchLists();
+  }, [watchLists]);
 
-    useEffect(() => {
-        if (watchLists.length === 0)
-        fetchGetWatchLists();
-    }, [watchLists]);
+  const handleEditClick = (watchList: WatchList) => {
+    setEditingWatchList(watchList);
+  };
 
-    return (
-        <>
-            <div>
-                <h2>All WatchLists</h2>
-                <ul>
-                    {watchLists.map((watchList) => (
-                        <li key={watchList.id}>
-                            <h3>{watchList.name}</h3>
-                            <p>{watchList.description}</p>
-                        </li>
-                    ))}
-                </ul>
-            </div>
-        </>
-    )
+  const handleUpdatedWatchList = (updatedWatchList: WatchList) => {
+    const updatedWatchLists = watchLists.map((watchList) =>
+      watchList.id === updatedWatchList.id ? updatedWatchList : watchList
+    );
+    setWatchLists(updatedWatchLists);
+
+    setEditingWatchList(null);
+  };
+
+  const handleCancelEditClick = () => {
+    setEditingWatchList(null);
+  };
+
+  return (
+    <>
+      <div>
+        <h2>All WatchLists</h2>
+        <ul>
+          {watchLists.map((watchList) => (
+            <li key={watchList.id}>
+              <h3>{watchList.name}</h3>
+              <p>{watchList.description}</p>
+              <button onClick={() => handleEditClick(watchList)}>Edit</button>
+              
+              
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {editingWatchList && (
+                <EditWatchListForm
+                  watchList={editingWatchList}
+                  onUpdate={handleUpdatedWatchList}
+                />
+      )}
+    </>
+  );
 }

--- a/telli-react/src/components/ViewWatchLists.tsx
+++ b/telli-react/src/components/ViewWatchLists.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import EditWatchListForm from "./EditWatchListForm";
 import DeleteWatchListButton from "./DeleteWatchListButton";
+import EditWatchListButton from "./EditWatchListButton";
 
 export interface WatchList {
   id: number;
@@ -56,9 +57,7 @@ export default function DisplayAllWatchLists() {
                 <>
                   <h3>{watchList.name}</h3>
                   <p>{watchList.description}</p>
-                  <button onClick={() => handleEditClick(watchList)}>
-                    Edit
-                  </button>
+                  <EditWatchListButton onClick={() => handleEditClick(watchList)} />
                   <DeleteWatchListButton onDelete={fetchGetWatchLists} watchListId={watchList.id} />
                 </>
               )}


### PR DESCRIPTION
Creates ability to dynamically decide what kind of media is being added through an additional API call. API KEY portion of fetch call within handleAddToWatchlist is blank for now. The idea is: the prop mediaTitle is grabbed from and tied to the actual title of the show or movie that would be displayed on the 'details' page. This prop might need to be renamed once details pages are fleshed out. Logic for finding the mediaType might need to be adjusted based on where the movie/show was pulled from in the External API